### PR TITLE
Add http source type

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .env
 bin
 *.py[co]
+*.out

--- a/examples/http_config.json
+++ b/examples/http_config.json
@@ -11,8 +11,8 @@
         "default": {
             "type": "http"
         },
-        "trip-photos": {
-            "host": "fast-image-testing.s3.amazonaws.com"
+        "profile-photos": {
+            "host": "bucket.s3.amazonaws.com"
         }
     },
     "processors": {
@@ -24,15 +24,15 @@
             "max_image_width": 1000
 
         },
-        "trip-photos": {
+        "profile-photos": {
             "default_image_width": 120
         }
     },
     "routes": {
         "^/thumbnail(?P<image_path>/.*?)(\\.(?P<width>[0-9]+)x(?P<height>[0-9]+)(?P<extension>\\.\\w+))?$": {
-            "name": "trip-photos",
-            "source": "trip-photos",
-            "processor": "trip-photos"
+            "name": "profile-photos",
+            "source": "profile-photos",
+            "processor": "profile-photos"
         }
     }
 }

--- a/examples/http_config.json
+++ b/examples/http_config.json
@@ -1,0 +1,38 @@
+{
+    "server": {
+        "port": 8849,
+        "read_timeout": 5,
+        "write_timeout": 30
+    },
+    "statsd": {
+      "enabled": false
+    },
+    "sources": {
+        "default": {
+            "type": "http"
+        },
+        "trip-photos": {
+            "host": "fast-image-testing.s3.amazonaws.com"
+        }
+    },
+    "processors": {
+        "default": {
+            "image_compression_quality": 85,
+            "default_scale_mode": "aspect_fill",
+            "max_blur_radius_percentage": 0,
+            "max_image_height": 0,
+            "max_image_width": 1000
+
+        },
+        "trip-photos": {
+            "default_image_width": 120
+        }
+    },
+    "routes": {
+        "^/thumbnail(?P<image_path>/.*?)(\\.(?P<width>[0-9]+)x(?P<height>[0-9]+)(?P<extension>\\.\\w+))?$": {
+            "name": "trip-photos",
+            "source": "trip-photos",
+            "processor": "trip-photos"
+        }
+    }
+}

--- a/examples/http_config.json
+++ b/examples/http_config.json
@@ -12,7 +12,8 @@
             "type": "http"
         },
         "profile-photos": {
-            "host": "bucket.s3.amazonaws.com"
+            "host": "bucket.s3.amazonaws.com",
+	    "scheme": "https"
         }
     },
     "processors": {

--- a/halfshell/config.go
+++ b/halfshell/config.go
@@ -65,7 +65,7 @@ type SourceConfig struct {
 	S3Bucket    string
 	S3SecretKey string
 	Directory   string
-        Host        string
+	Host        string
 }
 
 // ProcessorConfig holds the configuration settings for the image processor.

--- a/halfshell/config.go
+++ b/halfshell/config.go
@@ -66,6 +66,7 @@ type SourceConfig struct {
 	S3SecretKey string
 	Directory   string
 	Host        string
+	Scheme      string
 }
 
 // ProcessorConfig holds the configuration settings for the image processor.
@@ -220,6 +221,7 @@ func (c *configParser) parseSourceConfig(sourceName string) *SourceConfig {
 		S3Bucket:    c.stringForKeypath("sources.%s.s3_bucket", sourceName),
 		Directory:   c.stringForKeypath("sources.%s.directory", sourceName),
 		Host:        c.stringForKeypath("sources.%s.host", sourceName),
+		Scheme:      c.stringForKeypath("sources.%s.scheme", sourceName),	
 	}
 }
 

--- a/halfshell/config.go
+++ b/halfshell/config.go
@@ -65,6 +65,7 @@ type SourceConfig struct {
 	S3Bucket    string
 	S3SecretKey string
 	Directory   string
+        Host        string
 }
 
 // ProcessorConfig holds the configuration settings for the image processor.
@@ -218,6 +219,7 @@ func (c *configParser) parseSourceConfig(sourceName string) *SourceConfig {
 		S3SecretKey: c.stringForKeypath("sources.%s.s3_secret_key", sourceName),
 		S3Bucket:    c.stringForKeypath("sources.%s.s3_bucket", sourceName),
 		Directory:   c.stringForKeypath("sources.%s.directory", sourceName),
+		Host:        c.stringForKeypath("sources.%s.host", sourceName),
 	}
 }
 

--- a/halfshell/route.go
+++ b/halfshell/route.go
@@ -40,7 +40,6 @@ type Route struct {
 	Processor      ImageProcessor
 	Source         ImageSource
 	Statter        Statter
-	Logger         *Logger
 }
 
 // NewRouteWithConfig returns a pointer to a new Route instance created using
@@ -56,7 +55,6 @@ func NewRouteWithConfig(config *RouteConfig, statterConfig *StatterConfig) *Rout
 		Processor:      NewImageProcessorWithConfig(config.ProcessorConfig),
 		Source:         NewImageSourceWithConfig(config.SourceConfig),
 		Statter:        NewStatterWithConfig(config, statterConfig),
-		Logger: NewLogger("source.http.%s", config.Name),
 	}
 }
 
@@ -70,9 +68,6 @@ func (p *Route) ShouldHandleRequest(r *http.Request) bool {
 // from the request.
 func (p *Route) SourceAndProcessorOptionsForRequest(r *http.Request) (
 	*ImageSourceOptions, *ImageProcessorOptions) {
-
-	p.Logger.Infof("matching url: %v", r.URL.Path)
-	p.Logger.Infof("query: %v", r.URL.RawQuery)
 
 	matches := p.Pattern.FindAllStringSubmatch(r.URL.Path, -1)[0]
 	path := matches[p.ImagePathIndex]

--- a/halfshell/source.go
+++ b/halfshell/source.go
@@ -38,6 +38,7 @@ type ImageSource interface {
 
 type ImageSourceOptions struct {
 	Path string
+	Query string
 }
 
 func RegisterSource(sourceType ImageSourceType, factory ImageSourceFactoryFunction) {

--- a/halfshell/source.go
+++ b/halfshell/source.go
@@ -37,7 +37,7 @@ type ImageSource interface {
 }
 
 type ImageSourceOptions struct {
-	Path string
+	Path  string
 	Query string
 }
 

--- a/halfshell/source_http.go
+++ b/halfshell/source_http.go
@@ -1,0 +1,95 @@
+// Copyright (c) 2014 Oyster
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package halfshell
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+const (
+	ImageSourceTypeHttp ImageSourceType = "http"
+)
+
+type HttpImageSource struct {
+	Config *SourceConfig
+	Logger *Logger
+}
+
+func NewHttpImageSourceWithConfig(config *SourceConfig) ImageSource {
+	return &HttpImageSource{
+		Config: config,
+		Logger: NewLogger("source.http.%s", config.Name),
+	}
+}
+
+func (s *HttpImageSource) GetImage(request *ImageSourceOptions) (*Image, error) {
+	httpRequest := s.signedHTTPRequestForRequest(request)
+	httpResponse, err := http.DefaultClient.Do(httpRequest)
+	defer httpResponse.Body.Close()
+	if err != nil {
+		s.Logger.Warnf("Error downlading image: %v", err)
+		return nil, err
+	}
+	if httpResponse.StatusCode != 200 {
+		s.Logger.Infof("non 200 response received %v", httpResponse);
+		return nil, fmt.Errorf("Error downlading image (url=%v)", httpRequest.URL)
+	}
+	image, err := NewImageFromBuffer(httpResponse.Body)
+	if err != nil {
+		responseBody, _ := ioutil.ReadAll(httpResponse.Body)
+		s.Logger.Warnf("Unable to create image from response body: %v (url=%v)", string(responseBody), httpRequest.URL)
+		return nil, err
+	}
+	s.Logger.Infof("Successfully retrieved image from Http: %v", httpRequest.URL)
+	return image, nil
+}
+
+func (s *HttpImageSource) signedHTTPRequestForRequest(request *ImageSourceOptions) *http.Request {
+        imageURLPathComponents := strings.Split(request.Path, "/")
+        for index, component := range imageURLPathComponents {
+                component = url.QueryEscape(component)
+                imageURLPathComponents[index] = component
+        }
+        requestURL := &url.URL{
+                Opaque: strings.Join(imageURLPathComponents, "/"),
+                Scheme: "http",
+                Host:   s.Config.Host,
+		RawQuery: request.Query,
+        }
+
+	s.Logger.Infof("Fetching URI %v", requestURL.RequestURI())
+	s.Logger.Infof("Fetching URL %v", requestURL.String())
+
+	httpRequest, _ := http.NewRequest("GET", requestURL.String(), nil)
+	httpRequest.URL = requestURL
+	httpRequest.Header.Set("Date", time.Now().UTC().Format(http.TimeFormat))
+
+	return httpRequest
+}
+
+func init() {
+	RegisterSource(ImageSourceTypeHttp, NewHttpImageSourceWithConfig)
+}

--- a/halfshell/source_http.go
+++ b/halfshell/source_http.go
@@ -46,7 +46,7 @@ func NewHttpImageSourceWithConfig(config *SourceConfig) ImageSource {
 }
 
 func (s *HttpImageSource) GetImage(request *ImageSourceOptions) (*Image, error) {
-	httpRequest := s.unsignedHTTPRequestForRequest(request)
+	httpRequest := s.httpRequestForRequest(request)
 	httpResponse, err := http.DefaultClient.Do(httpRequest)
 	defer httpResponse.Body.Close()
 	if err != nil {
@@ -67,7 +67,7 @@ func (s *HttpImageSource) GetImage(request *ImageSourceOptions) (*Image, error) 
 	return image, nil
 }
 
-func (s *HttpImageSource) unsignedHTTPRequestForRequest(request *ImageSourceOptions) *http.Request {
+func (s *HttpImageSource) httpRequestForRequest(request *ImageSourceOptions) *http.Request {
 	imageURLPathComponents := strings.Split(request.Path, "/")
 	for index, component := range imageURLPathComponents {
 		component = url.QueryEscape(component)
@@ -75,7 +75,7 @@ func (s *HttpImageSource) unsignedHTTPRequestForRequest(request *ImageSourceOpti
 	}
 	requestURL := &url.URL{
 		Opaque:   strings.Join(imageURLPathComponents, "/"),
-		Scheme:   "http",
+		Scheme:   s.Config.Scheme,
 		Host:     s.Config.Host,
 		RawQuery: request.Query,
 	}

--- a/halfshell/source_http.go
+++ b/halfshell/source_http.go
@@ -46,7 +46,7 @@ func NewHttpImageSourceWithConfig(config *SourceConfig) ImageSource {
 }
 
 func (s *HttpImageSource) GetImage(request *ImageSourceOptions) (*Image, error) {
-	httpRequest := s.signedHTTPRequestForRequest(request)
+	httpRequest := s.unsignedHTTPRequestForRequest(request)
 	httpResponse, err := http.DefaultClient.Do(httpRequest)
 	defer httpResponse.Body.Close()
 	if err != nil {
@@ -54,7 +54,7 @@ func (s *HttpImageSource) GetImage(request *ImageSourceOptions) (*Image, error) 
 		return nil, err
 	}
 	if httpResponse.StatusCode != 200 {
-		s.Logger.Infof("non 200 response received %v", httpResponse);
+		s.Logger.Infof("non 200 response received %v", httpResponse)
 		return nil, fmt.Errorf("Error downlading image (url=%v)", httpRequest.URL)
 	}
 	image, err := NewImageFromBuffer(httpResponse.Body)
@@ -67,18 +67,18 @@ func (s *HttpImageSource) GetImage(request *ImageSourceOptions) (*Image, error) 
 	return image, nil
 }
 
-func (s *HttpImageSource) signedHTTPRequestForRequest(request *ImageSourceOptions) *http.Request {
-        imageURLPathComponents := strings.Split(request.Path, "/")
-        for index, component := range imageURLPathComponents {
-                component = url.QueryEscape(component)
-                imageURLPathComponents[index] = component
-        }
-        requestURL := &url.URL{
-                Opaque: strings.Join(imageURLPathComponents, "/"),
-                Scheme: "http",
-                Host:   s.Config.Host,
+func (s *HttpImageSource) unsignedHTTPRequestForRequest(request *ImageSourceOptions) *http.Request {
+	imageURLPathComponents := strings.Split(request.Path, "/")
+	for index, component := range imageURLPathComponents {
+		component = url.QueryEscape(component)
+		imageURLPathComponents[index] = component
+	}
+	requestURL := &url.URL{
+		Opaque:   strings.Join(imageURLPathComponents, "/"),
+		Scheme:   "http",
+		Host:     s.Config.Host,
 		RawQuery: request.Query,
-        }
+	}
 
 	s.Logger.Infof("Fetching URI %v", requestURL.RequestURI())
 	s.Logger.Infof("Fetching URL %v", requestURL.String())


### PR DESCRIPTION
Added a new source type for simple http.  This mirrors most of the s3 source except with no signing or bucket.  Additionally added logic to pass the query parameters through from the initial request to the end host.  I could see making the parameter pass through configurable, though for the current use case (public s3) we want them.
